### PR TITLE
Fixed mentionedBy() to check for lowercase "bucket"

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -358,11 +358,11 @@ async function mentionedBy(message) {
 	let channel = message.channel;
 
 	let content = message.content;
-	if (content.startsWith('bucket') || content.startsWith(`<@${client.user.id}>`))
-		content = content.substring(content.indexOf(' ') + 1);
-	else content = content.substring(0, content.lastIndexOf(', bucket'));
-
 	let lower = content.toLowerCase();
+	if (lower.startsWith('bucket') || content.startsWith(`<@${client.user.id}>`))
+		lower = lower.substring(lower.indexOf(' ') + 1);
+	else lower = lower.substring(0, lower.lastIndexOf(', bucket'));
+
 	let words = getWords(lower);
 
 	let silenced = await getSilencedState();


### PR DESCRIPTION
Originally the check was for "bucket" but content hadn't be lowered so it wasn't catching all of the times he was mentioned without using Discord's mention `@Bucket`